### PR TITLE
Add updateTime to meta topic for device with battery

### DIFF
--- a/index.js
+++ b/index.js
@@ -420,7 +420,6 @@ WBMQTTNative.prototype.getDeviceMetaArray = function (device) {
 			break;
 		case WBMQTTNative.zWaveDeviceType.battery:
 			addMetaTopicValue("updatetime", device.get("updateTime"));
-			break;
 		case WBMQTTNative.zWaveDeviceType.sensorMultilevel:
 			addMetaTopicValue("type", "value");
 			addMetaTopicValue("units", device.get("metrics:scaleTitle"));

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ WBMQTTNative.prototype.onConnect = function () {
 	self.log("Connected to " + self.config.host + " as " + self.config.clientId, WBMQTTNative.LoggingLevel.INFO);
 
 	self.controller.devices.on("change:metrics:level", self.updateCallback);
+	self.controller.devices.on("change:updateTime", self.updateCallback);
 	self.controller.devices.on('created', self.addCallback);
 	self.controller.devices.on('removed', self.removeCallback);
 
@@ -159,6 +160,7 @@ WBMQTTNative.prototype.updateDevice = function (device) {
 
 	if (self.shouldSkip(device)) return;
 
+	self.publishDeviceMeta(device);
 	self.publishDeviceValue(device);
 };
 
@@ -191,6 +193,7 @@ WBMQTTNative.prototype.onDisconnect = function () {
 	var self = this;
 
 	self.controller.devices.off("change:metrics:level", self.updateCallback);
+	self.controller.devices.off("change:updateTime", self.updateCallback);
 	self.controller.devices.off("created", self.addCallback);
 	self.controller.devices.off("removed", self.removeCallback);
 
@@ -416,6 +419,8 @@ WBMQTTNative.prototype.getDeviceMetaArray = function (device) {
 			addMetaTopicValue("readonly", "true");
 			break;
 		case WBMQTTNative.zWaveDeviceType.battery:
+			addMetaTopicValue("updatetime", device.get("updateTime"));
+			break;
 		case WBMQTTNative.zWaveDeviceType.sensorMultilevel:
 			addMetaTopicValue("type", "value");
 			addMetaTopicValue("units", device.get("metrics:scaleTitle"));


### PR DESCRIPTION
Added information about the last data sent - updateTime - to the meta topic for devices with a battery. Because It is possible that the connection with the device will be lost and we will not know about it in wirenboard. This problem is especially critical, for example, for leakage sensors.

Example of use in wb-rules:


```javascript
var zwaveSensors = [
  {
    'mqttTopicBattery': '/devices/zway-2/controls/Battery (2) 2-0-128/meta/updatetime',
    'title': 'Z-Wave. Leak Detector, id 2', 
    'updateTime': 0,
    'wasOnline': true
  }
];


// Consider devices offline if the last battery status update was greater than offlineUpdateTime seconds ago
var offlineUpdateTime = 5400; // 1 hour 30 minutes

// Subscribe to mqtt topic with updatetime
for (sensor in zwaveSensors) {
  trackMqtt(zwaveSensors[sensor].mqttTopicBattery, function(message){
    zwaveSensors[sensor].updateTime = message.value;
  });
}

// Logging and alerting functions
function deviceOnlineReport (sensor) {
  log("Device: {}, Topic: {}, device is returned Online!", sensor.title, sensor.mqttTopicBattery);
}

function deviceOfflineReport (sensor, delay) {
  log("Device: {}, Topic: {}, the device did not respond for more than {} minutes", sensor.title, sensor.mqttTopicBattery, delay);
}

function deviceDailyOfflineReport (sensor) {
  log("Device: {}, Topic: {}, device is Offline.", sensor.title, sensor.mqttTopicBattery);
}


// Checking the last data sent from the device
defineRule("sensor_zwave_check_status", {
  when: cron("00 00 */1 * *"),
  then: function () {
    var dateNow = Math.floor(Date.now() / 1000); 

    for (sensor in zwaveSensors) {
      var updateTime = zwaveSensors[sensor].updateTime;
      
      if (updateTime < 0) {
        log.error("Error reading mqtt topic {}", zwaveSensors[sensor].mqttTopicBattery);
        continue;
      }
      
      var delay = dateNow - zwaveSensors[sensor].updateTime;
      var isOnline = delay < offlineUpdateTime;
      
      if (isOnline != zwaveSensors[sensor].wasOnline) {
          isOnline
          ? deviceOnlineReport(zwaveSensors[sensor])
          : deviceOfflineReport(zwaveSensors[sensor],Math.floor(delay/60));
      }
    
      zwaveSensors[sensor].wasOnline = isOnline;
    }
  }
});

// Reminder once a day that the device is not connected
defineRule("sensor_zwave_offline", {
  when: cron("00 05 12 * *"),
  then: function () {
    for (sensor in zwaveSensors) {
      if (zwaveSensors[sensor].wasOnline === false) {
        deviceDailyOfflineReport(zwaveSensors[sensor]);
      }
    }
  }
});
```

